### PR TITLE
Remove custom Windows build script

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,9 +1,0 @@
-:: We set the version in the pin file but the build expects this to be a directory.
-:: we should wither patch it or send a PR upstream to avoid this workaround.
-set hdf4=
-
-set LIBRARY_DIRS=%LIBRARY_BIN%;%LIBRARY_LIB%
-set INCLUDE_DIRS=%LIBRARY_INC%
-
-REM %PYTHON% -m pip install . --no-deps -vv
-%PYTHON% setup.py install --single-version-externally-managed --record record.txt

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,9 +9,8 @@ source:
   sha256: c3a3bbfbd22c6c97a62b4149f746461b9816d93dd08ce1c9315bd642625426a3
 
 build:
-  number: 0
-  skip: True  # [win]
-  script: {{ PYTHON }} -m pip install . -vv  # [not win]
+  number: 1
+  script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   build:


### PR DESCRIPTION
Windows builds were turned off in #43 due to build failures. Let's see if this fixes it.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
